### PR TITLE
Adding NeoVim support

### DIFF
--- a/vims
+++ b/vims
@@ -58,5 +58,5 @@ if [ -x "$NVIM_BIN" ]; then
 elif [ -x "$VIM_BIN" ]; then
   ${VIM_BIN} - -nes "${vim_cmds[@]}" -c ':q!' | tail -n +2
 else
-  echo "Nor vim and nvim are installed!"
+  echo "Neither vim nor nvim are installed!"
 fi

--- a/vims
+++ b/vims
@@ -49,5 +49,14 @@ if [ "$DISABLE_VIMRC" -eq "1" ]; then
     vim_cmds=(-u NONE "${vim_cmds[@]}")
 fi
 
-vim - -nes "${vim_cmds[@]}" -c ':q!' | tail -n +2
+# locate the vim/nvim binaries
+VIM_BIN="$(whereis -b vim | awk '{print $2}')"
+NVIM_BIN="$(whereis -b nvim | awk '{print $2}')"
 
+if [ -x "$NVIM_BIN" ]; then
+  ${NVIM_BIN} - -nes "${vim_cmds[@]}" -c ':q!'
+elif [ -x "$VIM_BIN" ]; then
+  ${VIM_BIN} - -nes "${vim_cmds[@]}" -c ':q!' | tail -n +2
+else
+  echo "Nor vim and nvim are installed!"
+fi


### PR DESCRIPTION
Hello, I would like to update vim-stream to support NeoVim. It would be almost straightforward, except the nvim's pipe mode does not print the "Vim: Reading from stdin..." message, thus the `tail` is not necessary.

I am not sure whether the use of `whereis` and `awk` to detect the path to Vim/NeoVim binary is correct. Please correct me, if there is a better way. In this case the $VIM/$NVIM variables are empty when Vim or NeoVim is not installed.