### PR TITLE
Read from stdin and write to stdout to preserve `^I` tabs

### DIFF
--- a/vims
+++ b/vims
@@ -80,14 +80,14 @@ while :; do
 done
 
 # Headless vim which exits after printing all lines
-# Taken from Csaba Hoch:
-# https://groups.google.com/forum/#!msg/vim_use/NfqbCdUkDb4/Ir0faiNaFZwJ
 if [ "$PRINT_ALL" -eq "1" ]; then
-    set -- "$@" -c ":%p"
+    set -- "$@" -c "%w! /dev/stdout | q!"
+else
+    set -- "$@" -c "q!"
 fi
 if [ "$DISABLE_VIMRC" -eq "1" ]; then
     set -- -u NONE "$@"
 fi
 
 # Finally, we execute the stored array of vim commands:
-vim - -nes "$@" -c ':q!' | tail -n +2
+vim -nes "$@" /dev/stdin


### PR DESCRIPTION
hey i was doing something similar and came up with 

```bash
ex -sn "${@/#/+}" +'%write! /dev/stdout | quit!' /dev/stdin
```

I found your project while searching for the 10 commands limit. This PR changes the following and tests passed on my end

1. use `%w! /dev/stdout` to preserve tabs, because `%p` will change tabs to spaces (https://vi.stackexchange.com/a/23203)
2. merge print and quit commands to save a `-c` argument
3. read from `/dev/stdin` instead of `-` with `tail -n +2` (I assume `tail` is to get rid of `Vim: Reading from stdin...`)